### PR TITLE
Add CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ from depgraph_hsic_only import HSICYolov8SegPruner
 pruner = HSICYolov8SegPruner(ratio_target=0.6)
 pruner.run()
 ```
+
+You can also run a pruner from the command line::
+
+    python -m depgraph_hsic_only --pruner hsic --pretrained model.pt

--- a/depgraph_hsic_only/__main__.py
+++ b/depgraph_hsic_only/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - package entrypoint
+    main()

--- a/depgraph_hsic_only/cli.py
+++ b/depgraph_hsic_only/cli.py
@@ -1,0 +1,60 @@
+import argparse
+
+from .yolov8_pruner import DefaultYolov8SegPruner
+from .hsic_pruner import HSICYolov8SegPruner
+
+
+def main() -> None:
+    """Entry point for running a pruner from the command line."""
+    parser = argparse.ArgumentParser(
+        description="Run YOLOv8 segmentation model pruners"
+    )
+    parser.add_argument(
+        "--pruner",
+        choices=["default", "hsic"],
+        default="default",
+        help="Pruner implementation to use",
+    )
+    parser.add_argument(
+        "--pretrained",
+        default="yolov8n-seg.pt",
+        help="Path to pretrained model",
+    )
+    parser.add_argument(
+        "--cfg",
+        default="default.yaml",
+        help="Training config for DefaultYolov8SegPruner",
+    )
+    parser.add_argument(
+        "--ratio-target", type=float, default=0.5, help="HSIC prune ratio target"
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=4, help="HSIC batch size"
+    )
+    parser.add_argument(
+        "--img-size", type=int, default=640, help="HSIC input image size"
+    )
+    parser.add_argument(
+        "--lambd-steps", type=int, default=10, help="HSIC lambda steps"
+    )
+
+    args = parser.parse_args()
+
+    if args.pruner == "default":
+        pruner = DefaultYolov8SegPruner(
+            pretrained_path=args.pretrained, cfg=args.cfg
+        )
+    else:
+        pruner = HSICYolov8SegPruner(
+            pretrained_path=args.pretrained,
+            ratio_target=args.ratio_target,
+            batch_size=args.batch_size,
+            img_size=args.img_size,
+            lambd_steps=args.lambd_steps,
+        )
+
+    pruner.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI wrapper
+    main()


### PR DESCRIPTION
## Summary
- expose command-line interface for running available pruners
- mention CLI usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68554ce5ea64832487ffad4a7f4efdf6