### PR TITLE
Remove argparse import

### DIFF
--- a/depgraph_hsic_only/yolov8_pruner.py
+++ b/depgraph_hsic_only/yolov8_pruner.py
@@ -17,7 +17,6 @@ Helper utilities for plotting metrics, model conversion and custom training
 hooks live in :mod:`depgraph_hsic_only.utils`.
 """
 
-import argparse
 import math
 import os
 from copy import deepcopy


### PR DESCRIPTION
## Summary
- remove unused argparse import from YOLOv8 pruner

## Testing
- `python -m py_compile depgraph_hsic_only/yolov8_pruner.py`

------
https://chatgpt.com/codex/tasks/task_b_6855511cae7c8324bec5f70151ae53fc