### PR TITLE
Add sample training configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ pruner.run()
 You can also run a pruner from the command line::
 
     python -m depgraph_hsic_only --pruner hsic --pretrained model.pt
+
+The repository provides a sample training configuration in ``default.yaml``.
+This file contains the dataset path and basic parameters used by
+``DefaultYolov8SegPruner``.  Pass a different file via ``--cfg`` to customize
+the training behaviour.

--- a/default.yaml
+++ b/default.yaml
@@ -1,0 +1,14 @@
+# Sample training configuration for DefaultYolov8SegPruner
+# Adjust paths and parameters as needed.
+
+# task type
+task: segment
+# dataset configuration
+data: coco128-seg.yaml
+# number of epochs for the initial training run
+epochs: 50
+# training batch size
+batch: 4
+# input image size
+imgsz: 640
+


### PR DESCRIPTION
## Summary
- include default YAML configuration used by DefaultYolov8SegPruner
- document configuration file in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685551987a4c8324944aef38e3b4d625