### PR TITLE
Add smoke test for DefaultYolov8SegPruner

### DIFF
--- a/tests/test_default_pruner_smoke.py
+++ b/tests/test_default_pruner_smoke.py
@@ -1,0 +1,9 @@
+from .test_yolov8_pruner import load_pruner_module
+
+
+def test_default_pruner_can_be_instantiated():
+    pruner_module = load_pruner_module()
+    DefaultYolov8SegPruner = pruner_module.DefaultYolov8SegPruner
+    pruner = DefaultYolov8SegPruner(pretrained_path="model.pt", cfg="cfg.yaml")
+    assert pruner.pretrained_path == "model.pt"
+    assert pruner.cfg == "cfg.yaml"


### PR DESCRIPTION
## Summary
- create smoke test to instantiate `DefaultYolov8SegPruner` using mocked imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685552e091208324ab7b8cd58ac102bb