### PR TITLE
Update imports for older Ultralytics versions

### DIFF
--- a/depgraph_hsic_only/utils.py
+++ b/depgraph_hsic_only/utils.py
@@ -16,13 +16,17 @@ from ultralytics import YOLO, __version__
 from ultralytics.nn.modules.block import C2f, Bottleneck
 from ultralytics.nn.modules.conv import Conv
 from ultralytics.engine.trainer import BaseTrainer
-from ultralytics.utils import (
-    yaml_load,
-    LOGGER,
-    RANK,
-    DEFAULT_CFG_DICT,
-    DEFAULT_CFG_KEYS,
-)
+try:  # pragma: no cover - fallback for older Ultralytics versions
+    from ultralytics.utils import (
+        yaml_load,
+        DEFAULT_CFG_DICT,
+        DEFAULT_CFG_KEYS,
+    )
+except Exception:  # pragma: no cover
+    from ultralytics.utils.files import yaml_load
+    from ultralytics.cfg import DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS
+
+from ultralytics.utils import LOGGER, RANK
 from ultralytics.utils.checks import check_yaml
 from ultralytics.utils.torch_utils import de_parallel
 from ultralytics.nn.tasks import attempt_load_one_weight

--- a/depgraph_hsic_only/yolov8_pruner.py
+++ b/depgraph_hsic_only/yolov8_pruner.py
@@ -34,7 +34,13 @@ from ultralytics.nn.modules.block import C2f, Bottleneck
 from ultralytics.nn.modules.conv import Conv
 from ultralytics.nn.tasks import attempt_load_one_weight
 from ultralytics.engine.trainer import BaseTrainer
-from ultralytics.utils import yaml_load, LOGGER, RANK, DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS
+try:  # pragma: no cover - fallback for older Ultralytics versions
+    from ultralytics.utils import yaml_load, DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS
+except Exception:  # pragma: no cover
+    from ultralytics.utils.files import yaml_load
+    from ultralytics.cfg import DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS
+
+from ultralytics.utils import LOGGER, RANK
 from ultralytics.utils.checks import check_yaml
 from ultralytics.utils.torch_utils import initialize_weights, de_parallel
 


### PR DESCRIPTION
## Summary
- add compatibility fallback imports for `yaml_load` and config constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68555bc5db748324bbc17094fc8882e9