### PR TITLE
Update YAML loader usage

### DIFF
--- a/depgraph_hsic_only/yolov8_pruner.py
+++ b/depgraph_hsic_only/yolov8_pruner.py
@@ -29,13 +29,14 @@ import torch
 import torch.nn as nn
 from matplotlib import pyplot as plt
 from ultralytics import YOLO, __version__
-from ultralytics.nn.modules import Detect, C2f, Conv, Bottleneck
+from ultralytics.nn.modules.head import Detect
+from ultralytics.nn.modules.block import C2f, Bottleneck
+from ultralytics.nn.modules.conv import Conv
 from ultralytics.nn.tasks import attempt_load_one_weight
-from ultralytics.yolo.engine.model import TASK_MAP
-from ultralytics.yolo.engine.trainer import BaseTrainer
-from ultralytics.yolo.utils import yaml_load, LOGGER, RANK, DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS
-from ultralytics.yolo.utils.checks import check_yaml
-from ultralytics.yolo.utils.torch_utils import initialize_weights, de_parallel
+from ultralytics.engine.trainer import BaseTrainer
+from ultralytics.utils import YAML, LOGGER, RANK, DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS
+from ultralytics.utils.checks import check_yaml
+from ultralytics.utils.torch_utils import initialize_weights, de_parallel
 
 import torch_pruning as tp
 
@@ -67,11 +68,11 @@ class DefaultYolov8SegPruner(Yolov8SegPruner):
         return model
 
     def train(self, model: YOLO) -> None:
-        cfg = yaml_load(check_yaml(self.cfg))
+        cfg = YAML.load(check_yaml(self.cfg))
         model.train_v2(**cfg)
 
     def prune_backbone(self, model: YOLO) -> None:
-        pruning_cfg = yaml_load(check_yaml(self.cfg))
+        pruning_cfg = YAML.load(check_yaml(self.cfg))
         self._batch_size = pruning_cfg['batch']
         pruning_cfg['data'] = "coco128.yaml"
         pruning_cfg['epochs'] = 10
@@ -157,7 +158,7 @@ class DefaultYolov8SegPruner(Yolov8SegPruner):
     def fine_tune(self, model: YOLO) -> None:
         if self._batch_size is None:
             raise RuntimeError("Model must be pruned before fine tuning")
-        cfg = yaml_load(check_yaml(self.cfg))
+        cfg = YAML.load(check_yaml(self.cfg))
         cfg['batch'] = self._batch_size
         model.train_v2(pruning=True, **cfg)
 

--- a/tests/test_yolov8_pruner.py
+++ b/tests/test_yolov8_pruner.py
@@ -47,72 +47,80 @@ def load_pruner_module():
 
     # ultralytics stubs
     ultralytics = types.ModuleType("ultralytics")
-    ultralytics.YOLO = type("YOLO", (), {})
-    ultralytics.__version__ = "0"
 
-    nn_modules = types.ModuleType("ultralytics.nn.modules")
+    nn_head = types.ModuleType("ultralytics.nn.modules.head")
+    nn_block = types.ModuleType("ultralytics.nn.modules.block")
+    nn_conv = types.ModuleType("ultralytics.nn.modules.conv")
     class Dummy:  # simple placeholder
         pass
-    nn_modules.Detect = Dummy
-    nn_modules.C2f = Dummy
-    nn_modules.Conv = Dummy
-    nn_modules.Bottleneck = Dummy
+    nn_head.Detect = Dummy
+    nn_block.C2f = Dummy
+    nn_block.Bottleneck = Dummy
+    nn_conv.Conv = Dummy
 
     nn_tasks = types.ModuleType("ultralytics.nn.tasks")
     nn_tasks.attempt_load_one_weight = dummy
 
     ultralytics_nn = types.ModuleType("ultralytics.nn")
-    ultralytics_nn.modules = nn_modules
+    ultralytics_nn.modules = types.SimpleNamespace(
+        head=nn_head, block=nn_block, conv=nn_conv
+    )
     ultralytics_nn.tasks = nn_tasks
 
-    engine_model = types.ModuleType("ultralytics.yolo.engine.model")
-    engine_model.TASK_MAP = {"segment": (None, object)}
+    engine_model = types.ModuleType("ultralytics.engine.model")
 
-    engine_trainer = types.ModuleType("ultralytics.yolo.engine.trainer")
+    engine_trainer = types.ModuleType("ultralytics.engine.trainer")
     class BaseTrainer:
         pass
     engine_trainer.BaseTrainer = BaseTrainer
 
-    yolo_engine = types.ModuleType("ultralytics.yolo.engine")
+    yolo_engine = types.ModuleType("ultralytics.engine")
     yolo_engine.model = engine_model
     yolo_engine.trainer = engine_trainer
 
-    yolo_utils = types.ModuleType("ultralytics.yolo.utils")
-    yolo_utils.yaml_load = lambda *a, **k: {}
+    yolo_utils = types.ModuleType("ultralytics.utils")
+    class YAML:
+        @staticmethod
+        def load(*a, **k):
+            return {}
+    yolo_utils.YAML = YAML
     yolo_utils.LOGGER = types.SimpleNamespace(info=dummy)
     yolo_utils.RANK = -1
     yolo_utils.DEFAULT_CFG_DICT = {}
     yolo_utils.DEFAULT_CFG_KEYS = []
 
-    checks = types.ModuleType("ultralytics.yolo.utils.checks")
+    checks = types.ModuleType("ultralytics.utils.checks")
     checks.check_yaml = lambda x: x
 
-    torch_utils = types.ModuleType("ultralytics.yolo.utils.torch_utils")
+    torch_utils = types.ModuleType("ultralytics.utils.torch_utils")
     torch_utils.initialize_weights = dummy
     torch_utils.de_parallel = lambda x: x
 
     yolo_utils.checks = checks
     yolo_utils.torch_utils = torch_utils
 
-    yolo_mod = types.ModuleType("ultralytics.yolo")
-    yolo_mod.engine = yolo_engine
-    yolo_mod.utils = yolo_utils
+    class YOLO:
+        task_map = {"segment": {"trainer": object}}
 
-    ultralytics.yolo = yolo_mod
+    ultralytics.engine = yolo_engine
+    ultralytics.utils = yolo_utils
     ultralytics.nn = ultralytics_nn
+    ultralytics.YOLO = YOLO
+    ultralytics.__version__ = "0"
 
     modules.update({
         "ultralytics": ultralytics,
+        "ultralytics.engine": yolo_engine,
+        "ultralytics.engine.model": engine_model,
+        "ultralytics.engine.trainer": engine_trainer,
+        "ultralytics.utils": yolo_utils,
+        "ultralytics.utils.checks": checks,
+        "ultralytics.utils.torch_utils": torch_utils,
         "ultralytics.nn": ultralytics_nn,
-        "ultralytics.nn.modules": nn_modules,
+        "ultralytics.nn.modules.head": nn_head,
+        "ultralytics.nn.modules.block": nn_block,
+        "ultralytics.nn.modules.conv": nn_conv,
         "ultralytics.nn.tasks": nn_tasks,
-        "ultralytics.yolo": yolo_mod,
-        "ultralytics.yolo.engine": yolo_engine,
-        "ultralytics.yolo.engine.model": engine_model,
-        "ultralytics.yolo.engine.trainer": engine_trainer,
-        "ultralytics.yolo.utils": yolo_utils,
-        "ultralytics.yolo.utils.checks": checks,
-        "ultralytics.yolo.utils.torch_utils": torch_utils,
     })
 
     with mock.patch.dict(sys.modules, modules):


### PR DESCRIPTION
## Summary
- import `YAML` helper from ultralytics
- call `YAML.load` rather than deprecated `yaml_load`
- adjust tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68555681e6308324a81075fcfbf3de02