### PR TITLE
Guard optional HSIC imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The repository now includes two implementations:
   HSIC‑Lasso.  Filters with zero coefficients are removed and the graph is
   updated before fine‑tuning.
 
+  HSIC-based pruning requires the optional `pyHSICLasso` package.
+
 Both classes load a pretrained model, run training, prune the backbone layers
 and export the result to ONNX format.  Utility helpers for model conversion,
 training hooks and metric plotting are provided in ``depgraph_hsic_only.utils``.

--- a/depgraph_hsic_only/__init__.py
+++ b/depgraph_hsic_only/__init__.py
@@ -1,9 +1,14 @@
 from .pruner_base import Yolov8SegPruner
 from .yolov8_pruner import DefaultYolov8SegPruner
-from .hsic_pruner import HSICYolov8SegPruner
+
+try:
+    from .hsic_pruner import HSICYolov8SegPruner
+except ImportError:  # pragma: no cover
+    HSICYolov8SegPruner = None
 
 __all__ = [
     "Yolov8SegPruner",
     "DefaultYolov8SegPruner",
-    "HSICYolov8SegPruner",
 ]
+if HSICYolov8SegPruner is not None:
+    __all__.append("HSICYolov8SegPruner")


### PR DESCRIPTION
## Summary
- handle optional `HSICYolov8SegPruner` import in package `__init__`
- document that HSIC pruning depends on `pyHSICLasso`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68558a696db88324b6d5ee7991db692b