### PR TITLE
Improve docs for running the pruner

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,28 @@ The repository provides a sample training configuration in ``default.yaml``.
 This file contains the dataset path and basic parameters used by
 ``DefaultYolov8SegPruner``.  Pass a different file via ``--cfg`` to customize
 the training behaviour.
+
+## Installation
+
+Install the required Python packages using ``pip``.  The repository includes
+a ``requirements.txt`` file::
+
+    pip install -r requirements.txt
+
+The default configuration expects the COCO128 segmentation dataset referenced
+in ``default.yaml`` (``data: coco128-seg.yaml``).  Ensure the dataset file is
+available locally or adjust the ``data`` path in the configuration.
+
+Running the pruner requires a recent PyTorch installation and, ideally, access
+to a CUDA-capable GPU for training and pruning.
+
+## Usage
+
+After installing the dependencies, you can invoke the package module or the
+stand‑alone script.  To run via the module entry point::
+
+    python -m depgraph_hsic_only --pretrained yolov8n-seg.pt
+
+Or run ``prune.py`` directly::
+
+    python prune.py --pretrained yolov8n-seg.pt --cfg default.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Basic dependencies for running the YOLOv8 segmentation pruner
+ultralytics
+torch
+torch-pruning
+matplotlib
+numpy


### PR DESCRIPTION
## Summary
- document dependency installation via `requirements.txt`
- describe dataset path and GPU requirements
- show example commands for the module entrypoint and `prune.py`
- add a basic `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855972af9408324a9ae7f98d08ac005