### PR TITLE
Fix config loading and update default YAML

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -1,14 +1,16 @@
-# Sample training configuration for DefaultYolov8SegPruner
+# Default training configuration for DefaultYolov8SegPruner
+# Mirrors the basic arguments found in ultralytics/cfg/default.yaml
 # Adjust paths and parameters as needed.
 
-# task type
+# Task type
 task: segment
-# dataset configuration
+# Model architecture or pretrained weights
+model: yolov8n-seg.pt
+# Dataset configuration
 data: coco128-seg.yaml
-# number of epochs for the initial training run
+# Number of epochs for the initial training run
 epochs: 50
-# training batch size
+# Training batch size
 batch: 4
-# input image size
+# Input image size
 imgsz: 640
-

--- a/depgraph_hsic_only/yolov8_pruner.py
+++ b/depgraph_hsic_only/yolov8_pruner.py
@@ -63,8 +63,7 @@ class DefaultYolov8SegPruner(Yolov8SegPruner):
         return model
 
     def train(self, model: YOLO) -> None:
-        cfg = YAML.load(check_yaml(self.cfg))
-        model.train_v2(**cfg)
+        model.train_v2(cfg=self.cfg)
 
     def prune_backbone(self, model: YOLO) -> None:
         pruning_cfg = YAML.load(check_yaml(self.cfg))
@@ -153,9 +152,7 @@ class DefaultYolov8SegPruner(Yolov8SegPruner):
     def fine_tune(self, model: YOLO) -> None:
         if self._batch_size is None:
             raise RuntimeError("Model must be pruned before fine tuning")
-        cfg = YAML.load(check_yaml(self.cfg))
-        cfg['batch'] = self._batch_size
-        model.train_v2(pruning=True, **cfg)
+        model.train_v2(pruning=True, cfg=self.cfg, batch=self._batch_size)
 
     def save_model(self, model: YOLO) -> None:
         model.export(format='onnx')


### PR DESCRIPTION
## Summary
- expand `default.yaml` so YOLO has all required params
- train using the YAML file directly and pass batch size for fine‑tuning

## Testing
- `pytest -q`
- `python -m depgraph_hsic_only --pretrained yolov8n-seg.pt --cfg default.yaml` *(fails: ModuleNotFoundError: No module named 'torch_pruning')*

------
https://chatgpt.com/codex/tasks/task_b_68559710cf048324aa91527d3988f7b4