### PR TITLE
Fix CLI defaults and add tests

### DIFF
--- a/depgraph_hsic_only/yolov8_pruner.py
+++ b/depgraph_hsic_only/yolov8_pruner.py
@@ -62,7 +62,7 @@ class DefaultYolov8SegPruner(Yolov8SegPruner):
     def train(self, model: YOLO) -> None:
         """Train the model using the provided config."""
         cfg = YAML.load(check_yaml(self.cfg))
-        model.train_v2(**cfg)
+        model.train_v2(data=self.cfg, **cfg)
 
 
     def prune_backbone(self, model: YOLO) -> None:

--- a/tests/test_cli_default.py
+++ b/tests/test_cli_default.py
@@ -1,0 +1,31 @@
+from importlib import import_module, reload
+import sys
+from unittest import mock
+
+from .test_yolov8_pruner import load_pruner_module
+
+
+def test_cli_runs_with_default_arguments(monkeypatch):
+    pruner_module = load_pruner_module()
+    with mock.patch.dict(sys.modules, {"depgraph_hsic_only.yolov8_pruner": pruner_module}):
+        cli = import_module("depgraph_hsic_only.cli")
+        reload(cli)
+        created = {}
+
+        class DummyPruner:
+            def __init__(self, pretrained_path, cfg):
+                created["pretrained"] = pretrained_path
+                created["cfg"] = cfg
+
+            def run(self):
+                created["ran"] = True
+
+        monkeypatch.setattr(cli, "DefaultYolov8SegPruner", DummyPruner)
+        monkeypatch.setattr(sys, "argv", ["prog"])
+        cli.main()
+
+    assert created == {
+        "pretrained": "yolov8n-seg.pt",
+        "cfg": "biotech_model_train.yaml",
+        "ran": True,
+    }

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,20 @@
+from .test_yolov8_pruner import load_pruner_module
+
+
+def test_train_passes_dataset_path():
+    pruner_module = load_pruner_module()
+    DefaultYolov8SegPruner = pruner_module.DefaultYolov8SegPruner
+
+    recorded = {}
+
+    class DummyModel:
+        def train_v2(self, **kwargs):
+            recorded.update(kwargs)
+
+    pruner = DefaultYolov8SegPruner(
+        pretrained_path="model.pt",
+        cfg="biotech_model_train.yaml",
+    )
+    pruner.train(DummyModel())
+
+    assert recorded.get("data") == "biotech_model_train.yaml"


### PR DESCRIPTION
## Summary
- pass dataset file path when training with DefaultYolov8SegPruner
- test that the pruner sends the dataset path to YOLO
- ensure CLI runs with default args

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855a633f05c8324bf57cfd6e303da1b