### PR TITLE
Add metric collector interfaces

### DIFF
--- a/metric_collector/__init__.py
+++ b/metric_collector/__init__.py
@@ -1,0 +1,11 @@
+"""Metric collector package."""
+
+from .pruning_metrics import PruningMetricCollector
+from .training_metrics import TrainingMetricCollector
+from .compute_metrics import ComputeMetricCollector
+
+__all__ = [
+    "PruningMetricCollector",
+    "TrainingMetricCollector",
+    "ComputeMetricCollector",
+]

--- a/metric_collector/compute_metrics.py
+++ b/metric_collector/compute_metrics.py
@@ -1,0 +1,33 @@
+"""Abstract collector for compute metrics."""
+
+from __future__ import annotations
+
+import abc
+
+
+class ComputeMetricCollector(abc.ABC):
+    """Collect metrics related to compute resources."""
+
+    @property
+    @abc.abstractmethod
+    def peak_memory(self) -> float:
+        """Return the peak memory usage."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def gpu_usage(self) -> float:
+        """Return the GPU utilisation."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def time(self) -> float:
+        """Return the elapsed time."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def power(self) -> float:
+        """Return the consumed power."""
+        raise NotImplementedError

--- a/metric_collector/pruning_metrics.py
+++ b/metric_collector/pruning_metrics.py
@@ -1,0 +1,33 @@
+"""Abstract collector for pruning metrics."""
+
+from __future__ import annotations
+
+import abc
+
+
+class PruningMetricCollector(abc.ABC):
+    """Collect metrics related to model pruning."""
+
+    @property
+    @abc.abstractmethod
+    def flops(self) -> float:
+        """Return the number of floating point operations."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def parameters(self) -> int:
+        """Return the number of model parameters."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def size(self) -> float:
+        """Return the serialized model size."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def filter_reduction(self) -> float:
+        """Return the fraction of filters removed."""
+        raise NotImplementedError

--- a/metric_collector/training_metrics.py
+++ b/metric_collector/training_metrics.py
@@ -1,0 +1,33 @@
+"""Abstract collector for training metrics."""
+
+from __future__ import annotations
+
+import abc
+
+
+class TrainingMetricCollector(abc.ABC):
+    """Collect metrics related to model training."""
+
+    @property
+    @abc.abstractmethod
+    def map(self) -> float:
+        """Return the mean average precision."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def recall(self) -> float:
+        """Return the recall value."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def precision(self) -> float:
+        """Return the precision value."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def map50_95(self) -> float:
+        """Return the mAP@50-95 score."""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- add `metric_collector` package
- define abstract metric collector classes for pruning, training, and compute metrics

## Testing
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6855d4c2a9088324acf63f9c1fc9096d