### PR TITLE
Add CLI runner

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,9 @@
 """depgraph_hsic_only package entry point."""
 
 from .prune_methods import HsicLassoPruner
+from .main import main
 
-__all__ = ["HsicLassoPruner"]
+__all__ = ["HsicLassoPruner", "main"]
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,37 @@
+"""Command-line entry point for the pruning pipeline."""
+
+from __future__ import annotations
+
+import argparse
+
+if __package__:
+    from .pipeline.yolo_pipeline import YoloPipeline
+else:  # pragma: no cover - direct script execution
+    from pipeline.yolo_pipeline import YoloPipeline
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line options."""
+    parser = argparse.ArgumentParser(description="Run the YOLO pruning pipeline")
+    parser.add_argument(
+        "--pretrained",
+        default="yolov8n-seg.pt",
+        help="Path to the pretrained YOLO model",
+    )
+    parser.add_argument(
+        "--config",
+        default="biotech_model_train.yaml",
+        help="Path to the training data configuration file",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Instantiate the pipeline and execute it."""
+    args = parse_args()
+    pipeline = YoloPipeline(model_path=args.pretrained, data=args.config)
+    pipeline.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/yolo_pipeline.py
+++ b/pipeline/yolo_pipeline.py
@@ -8,8 +8,13 @@ import torch
 from ultralytics import YOLO
 
 from .base import BasePruningPipeline
-from prune_methods.hsic_lasso import HsicLassoPruner
-from metric_collector import YoloTrainingMetrics, YoloPruningMetrics
+
+if __package__ and __package__.startswith("depgraph_hsic_only"):
+    from ..prune_methods.hsic_lasso import HsicLassoPruner
+    from ..metric_collector import YoloTrainingMetrics, YoloPruningMetrics
+else:  # pragma: no cover - direct script execution
+    from prune_methods.hsic_lasso import HsicLassoPruner
+    from metric_collector import YoloTrainingMetrics, YoloPruningMetrics
 
 
 


### PR DESCRIPTION
## Summary
- provide a `main.py` script to run the YOLO pruning pipeline
- expose `main()` via the package `__init__`
- support running the pipeline both as a script and as a module

## Testing
- `python main.py --help`
- `python -m pip --version`

------
https://chatgpt.com/codex/tasks/task_b_68565f237e688324b8bd93e7095c4d1d