### PR TITLE
Fix HSIC Lasso names extraction

### DIFF
--- a/prune_methods/hsic_lasso.py
+++ b/prune_methods/hsic_lasso.py
@@ -58,7 +58,7 @@ class HsicLassoPruner(BasePruningMethod):
 
         group_scores: dict[tp.Group, float] = {}
         for group in dependency_graph.get_all_groups():
-            names = [node.name for node in group.nodes]
+            names = [dep.target.name for dep, _ in group]
             kernels = []
             for nm in names:
                 X = feat_in[nm]


### PR DESCRIPTION
## Summary
- collect group names from each dependency's target node in `HsicLassoPruner`

## Testing
- `python -m py_compile prune_methods/hsic_lasso.py`


------
https://chatgpt.com/codex/tasks/task_b_68566c5452248324b9326255ef39c279